### PR TITLE
Add ellipses to certain command buttons

### DIFF
--- a/CSV Analyzer Pro/CSV Analyzer Pro/Form1.Designer.cs
+++ b/CSV Analyzer Pro/CSV Analyzer Pro/Form1.Designer.cs
@@ -109,14 +109,14 @@ namespace CSV_Analyzer_Pro
             // 
             this.newToolStripMenuItem.Name = "newToolStripMenuItem";
             this.newToolStripMenuItem.Size = new System.Drawing.Size(111, 22);
-            this.newToolStripMenuItem.Text = "New..";
+            this.newToolStripMenuItem.Text = "New";
             this.newToolStripMenuItem.Click += new System.EventHandler(this.newToolStripMenuItem_Click);
             // 
             // openToolStripMenuItem
             // 
             this.openToolStripMenuItem.Name = "openToolStripMenuItem";
             this.openToolStripMenuItem.Size = new System.Drawing.Size(111, 22);
-            this.openToolStripMenuItem.Text = "Open";
+            this.openToolStripMenuItem.Text = "Open...";
             this.openToolStripMenuItem.Click += new System.EventHandler(this.openToolStripMenuItem_Click);
             // 
             // saveToolStripMenuItem
@@ -130,7 +130,7 @@ namespace CSV_Analyzer_Pro
             // 
             this.saveAsToolStripMenuItem.Name = "saveAsToolStripMenuItem";
             this.saveAsToolStripMenuItem.Size = new System.Drawing.Size(111, 22);
-            this.saveAsToolStripMenuItem.Text = "SaveAs";
+            this.saveAsToolStripMenuItem.Text = "Save As...";
             this.saveAsToolStripMenuItem.Click += new System.EventHandler(this.saveAsToolStripMenuItem_Click);
             // 
             // rowsToolStripMenuItem
@@ -193,7 +193,7 @@ namespace CSV_Analyzer_Pro
             // 
             this.setToolStripMenuItem.Name = "setToolStripMenuItem";
             this.setToolStripMenuItem.Size = new System.Drawing.Size(102, 22);
-            this.setToolStripMenuItem.Text = "Set";
+            this.setToolStripMenuItem.Text = "Set...";
             this.setToolStripMenuItem.Click += new System.EventHandler(this.setToolStripMenuItem_Click);
             // 
             // resetToolStripMenuItem

--- a/CSV Analyzer Pro/CSV Analyzer Pro/Form1.cs
+++ b/CSV Analyzer Pro/CSV Analyzer Pro/Form1.cs
@@ -360,7 +360,7 @@ namespace CSV_Analyzer_Pro{
             //card.WireGrid(dbg);
             DataTable dt = new DataTable();
 
-            tb.Text = "New..";
+            tb.Text = "New";
 
             tb.Controls.Add(dbg);
             tabControl1.TabPages.Add(tb);


### PR DESCRIPTION
Certain command buttons such as "Open..." and "Save As..." usually have ellipses with them. (see [here](https://msdn.microsoft.com/en-us/library/windows/desktop/dn742402(v=vs.85).aspx) for rationale)

I thought it would be a good idea to add them to bring the UI into line with these conventions.