### PR TITLE
Alterations to CheckUpdate

### DIFF
--- a/CAPBuilds/0.0.4/ChangeLog.md
+++ b/CAPBuilds/0.0.4/ChangeLog.md
@@ -7,7 +7,8 @@
 
 
 ### Fixed
-
+- Fixed threading issue in CheckUpdate
+- Fixed unhandled exception on failure to connect to server while checking for updates
 
 ### TODO
 - Improve plugin system metadata into array structure

--- a/CSV Analyzer Pro/CSV Analyzer Pro/CheckUpdate.Designer.cs
+++ b/CSV Analyzer Pro/CSV Analyzer Pro/CheckUpdate.Designer.cs
@@ -66,7 +66,6 @@
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.Name = "CheckUpdate";
             this.Text = "CheckUpdate";
-            this.Load += new System.EventHandler(this.CheckUpdate_Load);
             this.ResumeLayout(false);
             this.PerformLayout();
 

--- a/CSV Analyzer Pro/CSV Analyzer Pro/CheckUpdate.cs
+++ b/CSV Analyzer Pro/CSV Analyzer Pro/CheckUpdate.cs
@@ -43,12 +43,22 @@ namespace CSV_Analyzer_Pro {
                     string errorMessage = string.Format("There was a problem connecting to the update server : {0}", ne.Message);
 
                     DialogResult userResponse = MessageBox.Show(errorMessage, "Failed to connect to server", MessageBoxButtons.RetryCancel, MessageBoxIcon.Error);
-                    if (userResponse == DialogResult.Cancel) {
-                        updaterUI.Abort();
-                        Application.Exit();
-                        Environment.Exit(1);
+                    if (userResponse != DialogResult.Retry) {
+                        label1.Text = "Update Failed";
+                        progressBar1.Value = 0;
+                        break;
                     }
                 }
+            }
+
+            if (connectionFailed) { // Show the main window early and exit once it is closed. Temporary measure.
+                Form1 form = new Form1();
+                form.ShowDialog();
+
+                updaterUI.Abort();
+
+                Application.Exit();
+                Environment.Exit(0);
 
             }
 
@@ -77,8 +87,8 @@ namespace CSV_Analyzer_Pro {
                     //Load
                     Form1 form = new Form1();
 
+                    form.ShowDialog();
                     updaterUI.Abort();
-                    form.Show();
                 }
             }
         }

--- a/CSV Analyzer Pro/CSV Analyzer Pro/CheckUpdate.cs
+++ b/CSV Analyzer Pro/CSV Analyzer Pro/CheckUpdate.cs
@@ -16,9 +16,13 @@ namespace CSV_Analyzer_Pro {
 
         public CheckUpdate() {
             InitializeComponent();
+            CheckUpdate_Load();
         }
 
-        private void CheckUpdate_Load(object sender, EventArgs e) {
+        private void CheckUpdate_Load() {
+            System.Threading.Thread updaterUI = new System.Threading.Thread(() => ShowDialog());
+            updaterUI.Start();
+
             WebClient wc = new WebClient();
             System.IO.Stream stream = wc.OpenRead("http://deathcrow.altervista.org/update.php");
             using(System.IO.StreamReader reader = new System.IO.StreamReader(stream)) {

--- a/CSV Analyzer Pro/CSV Analyzer Pro/CheckUpdate.cs
+++ b/CSV Analyzer Pro/CSV Analyzer Pro/CheckUpdate.cs
@@ -20,6 +20,9 @@ namespace CSV_Analyzer_Pro {
         }
 
         private void CheckUpdate_Load() {
+            label1.Text = "Connecting To Update Server";
+            progressBar1.Value = 15;
+
             System.Threading.Thread updaterUI = new System.Threading.Thread(() => ShowDialog());
             updaterUI.Start();
 
@@ -30,7 +33,7 @@ namespace CSV_Analyzer_Pro {
                 string[] texts = text.Split(',');
 
                 label1.Text = "Checking For Update";
-                progressBar1.Value = 10;
+                progressBar1.Value = 25;
 
                 if (thisVersion != texts[0]) {
                     //Update Available

--- a/CSV Analyzer Pro/CSV Analyzer Pro/Form1.Designer.cs
+++ b/CSV Analyzer Pro/CSV Analyzer Pro/Form1.Designer.cs
@@ -110,35 +110,35 @@ namespace CSV_Analyzer_Pro
             // newToolStripMenuItem
             // 
             this.newToolStripMenuItem.Name = "newToolStripMenuItem";
-            this.newToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.newToolStripMenuItem.Size = new System.Drawing.Size(123, 22);
             this.newToolStripMenuItem.Text = "New";
             this.newToolStripMenuItem.Click += new System.EventHandler(this.newToolStripMenuItem_Click);
             // 
             // openToolStripMenuItem
             // 
             this.openToolStripMenuItem.Name = "openToolStripMenuItem";
-            this.openToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.openToolStripMenuItem.Size = new System.Drawing.Size(123, 22);
             this.openToolStripMenuItem.Text = "Open...";
             this.openToolStripMenuItem.Click += new System.EventHandler(this.openToolStripMenuItem_Click);
             // 
             // saveToolStripMenuItem
             // 
             this.saveToolStripMenuItem.Name = "saveToolStripMenuItem";
-            this.saveToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.saveToolStripMenuItem.Size = new System.Drawing.Size(123, 22);
             this.saveToolStripMenuItem.Text = "Save";
             this.saveToolStripMenuItem.Click += new System.EventHandler(this.saveToolStripMenuItem_Click);
             // 
             // saveAsToolStripMenuItem
             // 
             this.saveAsToolStripMenuItem.Name = "saveAsToolStripMenuItem";
-            this.saveAsToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.saveAsToolStripMenuItem.Size = new System.Drawing.Size(123, 22);
             this.saveAsToolStripMenuItem.Text = "Save As...";
             this.saveAsToolStripMenuItem.Click += new System.EventHandler(this.saveAsToolStripMenuItem_Click);
             // 
             // saveAllToolStripMenuItem
             // 
             this.saveAllToolStripMenuItem.Name = "saveAllToolStripMenuItem";
-            this.saveAllToolStripMenuItem.Size = new System.Drawing.Size(152, 22);
+            this.saveAllToolStripMenuItem.Size = new System.Drawing.Size(123, 22);
             this.saveAllToolStripMenuItem.Text = "Save All";
             this.saveAllToolStripMenuItem.Click += new System.EventHandler(this.saveAllToolStripMenuItem_Click);
             // 

--- a/CSV Analyzer Pro/CSV Analyzer Pro/Form1.cs
+++ b/CSV Analyzer Pro/CSV Analyzer Pro/Form1.cs
@@ -369,7 +369,7 @@ namespace CSV_Analyzer_Pro{
             UnsavedChangesSingleFile unsavedChangesBox = new UnsavedChangesSingleFile();
             unsavedChangesBox.ShowDialog();
 
-            switch (unsavedChangesBox.userAnswer) {
+            switch (unsavedChangesBox.GetUserAnswer()) {
                case UnsavedChangesSingleFile.saveAndClose:
                     Save(tabInfo.GetAssocaitedFileName(), tabControl1.SelectedIndex);
                     DeleteTab();
@@ -386,7 +386,7 @@ namespace CSV_Analyzer_Pro{
             UnsavedChangesSingleFile unsavedChangesBox = new UnsavedChangesSingleFile();
             unsavedChangesBox.ShowDialog();
 
-            switch (unsavedChangesBox.userAnswer) {
+            switch (unsavedChangesBox.GetUserAnswer()) {
                case UnsavedChangesSingleFile.saveAndClose:
                     Save(tabInfo.GetAssocaitedFileName(), tabControl1.SelectedIndex);
                     return true;
@@ -434,7 +434,7 @@ namespace CSV_Analyzer_Pro{
             UnsavedChangesMultipleFiles unsavedChangesBox = new UnsavedChangesMultipleFiles();
             unsavedChangesBox.ShowDialog();
 
-            switch (unsavedChangesBox.userAnswer)
+            switch (unsavedChangesBox.GetUserAnswer())
             {
                 case UnsavedChangesMultipleFiles.saveAllAndClose:
                     SaveAll();

--- a/CSV Analyzer Pro/CSV Analyzer Pro/UnsavedChangesMultipleFiles.cs
+++ b/CSV Analyzer Pro/CSV Analyzer Pro/UnsavedChangesMultipleFiles.cs
@@ -11,7 +11,7 @@ using System.Windows.Forms;
 namespace CSV_Analyzer_Pro {
     public partial class UnsavedChangesMultipleFiles : Form {
 
-        public int userAnswer;
+        private int userAnswer;
         public const int saveAllAndClose = 1;
         public const int closeWithoutSaving = 2;
         public const int Cancel = 3;
@@ -34,5 +34,10 @@ namespace CSV_Analyzer_Pro {
             userAnswer = Cancel;
             Close();
         }
+
+        public int GetUserAnswer() {
+            return userAnswer;
+        }
+
     }
 }

--- a/CSV Analyzer Pro/CSV Analyzer Pro/UnsavedChangesSingleFile.cs
+++ b/CSV Analyzer Pro/CSV Analyzer Pro/UnsavedChangesSingleFile.cs
@@ -12,7 +12,7 @@ namespace CSV_Analyzer_Pro {
 
     public partial class UnsavedChangesSingleFile : Form {
 
-        public int userAnswer;
+        private int userAnswer;
         public const int saveAndClose = 1;
         public const int closeWithoutSaving = 2;
         public const int Cancel = 3;
@@ -34,6 +34,10 @@ namespace CSV_Analyzer_Pro {
         private void button3_Click(object sender, EventArgs e) {
             userAnswer = Cancel;
             Close();
+        }
+
+        public int GetUserAnswer() {
+            return userAnswer;
         }
 
     }


### PR DESCRIPTION
When I try to open the program it seems to hang a little with no feedback. The lack of feedback seems to have been a problem with the UI and processing logic sharing a thread and blocking each other, meaning the UI window never got a chance to draw itself until the checking was already over. The hanging appears to be dependent on how long it takes the user to connect to the update server and get a response, with the program silently failing if the connection times out or the server cannot be reached.

I tried to improve on these issues by changing the threading used in CheckUpdate, adding an extra step to the progress bar showing the attempt to connect to the update server and adding an exception handler for if the connection should fail for any reason.